### PR TITLE
Updated cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ Check out the bioRxiv manuscript [Zhang*, Hou*, et al. "Polygenic enrichment dis
 # Table of contents <!-- omit in toc -->
 - [Installation](#installation)
 - [Within python scDRS demo](#within-python-scdrs-demo)
-- [Make .gs file (CLI)](#make-gs-file-cli)
 - [Command line interface for scDRS score calculation](#command-line-interface-for-scdrs-score-calculation)
-- [scDRS downsteam applications (CLI)](#scdrs-downsteam-applications-cli)
+- [Command line interface for scDRS downsteam applications](#command-line-interface-for-scdrs-downsteam-applications)
 - [File formats](#file-formats)
   - [scDRS input files](#scdrs-input-files)
   - [scDRS output files](#scdrs-output-files)
@@ -78,15 +77,6 @@ The expected output is (see below for format of **.score.gz** file):
   | A17_B002755_B007347_S17.mm10-plus-7-0 | 5.379276  |  3.338063  | 0.003992 | 0.000800 |  3.096939   | 3.155926 |
   |    C22_B003856_S298_L004.mus-2-0-1    | 5.443514  |  4.537418  | 0.001996 | 0.000067 |  4.176120   | 3.820235 |
 
-# Make .gs file (CLI)
-- Input: space-delimited file with gene names in the first column, and the rest of columns as disease names and gene-level p-values or z-scores.
-- Output: weights gene set file used by scDRS.
-
-```sh
-scdrs make-gs \
-  --pval-file <pval-file> \ # replace this with --zscore-file <zscore-file> as needed
-  --out-file <out-file>
-```
 
 # Command line interface for scDRS score calculation 
 - Input: scRNA-seq data (**.h5ad** file) and gene set file (**.gs** file)
@@ -123,35 +113,32 @@ scdrs make-gs \
   - `--flag_return_ctrl_norm_score` ("True"/"False") : if to return normalized control scores
   - `--out_folder` : output folder. Score files will be saved as `{out_folder}/{trait}.score.gz` (see below for file format)
 
-# scDRS downsteam applications (CLI)
+# Command line interface for scDRS downsteam applications 
 - Input: scRNA-seq data (**.h5ad** file), gene set file (**.gs** file), and scDRS full score files (**.full_score.gz** files)
 - Output: **{trait}.scdrs_ct.{cell_type}** file for cell type-level analyses (association and heterogeneity); **{trait}.scdrs_var** file for cell variable-disease association; **{trait}.scdrs_gene** file for disease gene prioritization.
+  ```sh
+  h5ad_file=your_scrnaseq_data
+  out_dir=your_output_folder
+  python compute_downstream.py \
+      --h5ad_file ${h5ad_file}.h5ad \
+      --score_file @.full_score.gz \
+      --cell_type cell_type \
+      --cell_variable causal_variable,non_causal_variable,covariate\
+      --flag_gene True\
+      --flag_filter False\
+      --flag_raw_count False\
+      --out_folder ${out_dir}
+  ```
+  
 
-```sh
-h5ad_file=your_scrnaseq_data
-out_dir=your_output_folder
-scdrs downstream \
-    --h5ad_file ${h5ad_file}.h5ad \
-    --score_file @.full_score.gz \
-    --group-analysis <group-vars> \
-    --flag_filter False \
-    --flag_raw_count False \
-    --out_folder ${out_dir}
-```
-
-The line of `--group-analysis <group-vars>` can be replaced with
-- `--corr-analysis <corr_vars>` for correlation analysis between scDRS scores with some covariates.
-- `--gene-analysis` for gene prioritization.
-
-These options corresponds to
-- --`h5ad_file` (**.h5ad** file) : scRNA-seq data
-- --`score_file` (**.full_score.gz** files) : scDRS full score files; supporting use of "@" to match strings
-- --`group_analysis` (str) : cell type column (supporting multiple columns separated by comma); must be present in `adata.obs.columns`; used for cell type-disease association analyses (5% quantile as test statistic) and detecting association heterogeneity within cell type (Geary's C as test statistic)
-- --`corr_analysis` (str) : cell-level variable columns (supporting multiple columns separated by comma); must be present in `adata.obs.columns`; used for cell variable-disease association analyses (Pearson's correlation as test statistic)
-- --`gene-analysis` ("True"/"False") : if to correlate scDRS disease scores with gene expression
-- --`flag_filter` ("True"/"False") : if to perform minimum filtering of cells and genes
-- --`flag_raw_count` ("True"/"False") : if to perform normalization (size-factor + log1p)
-- --`out_folder` : output folder. Score files will be saved as `{out_folder}/{trait}.scdrs_ct.{cell_type}` for cell type-level analyses (association and heterogeneity); `{out_folder}/{trait}.scdrs_var` file for cell variable-disease association; `{out_folder}/{trait}.scdrs_var.{trait}.scdrs_gene` file for disease gene prioritization. (see below for file format)
+  - --`h5ad_file` (**.h5ad** file) : scRNA-seq data
+  - --`score_file` (**.full_score.gz** files) : scDRS full score files; supporting use of "@" to match strings
+  - --`cell_type` (str) : cell type column (supporting multiple columns separated by comma); must be present in `adata.obs.columns`; used for cell type-disease association analyses (5% quantile as test statistic) and detecting association heterogeneity within cell type (Geary's C as test statistic)
+  - --`cell_variable` (str) : cell-level variable columns (supporting multiple columns separated by comma); must be present in `adata.obs.columns`; used for cell variable-disease association analyses (Pearson's correlation as test statistic)
+  - --`flag_gene` ("True"/"False") : if to correlate scDRS disease scores with gene expression
+  - --`flag_filter` ("True"/"False") : if to perform minimum filtering of cells and genes
+  - --`flag_raw_count` ("True"/"False") : if to perform normalization (size-factor + log1p)
+  - --`out_folder` : output folder. Score files will be saved as `{out_folder}/{trait}.scdrs_ct.{cell_type}` for cell type-level analyses (association and heterogeneity); `{out_folder}/{trait}.scdrs_var` file for cell variable-disease association; `{out_folder}/{trait}.scdrs_var.{trait}.scdrs_gene` file for disease gene prioritization. (see below for file format)
     
 
 # File formats

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Check out the bioRxiv manuscript [Zhang*, Hou*, et al. "Polygenic enrichment dis
 # Table of contents <!-- omit in toc -->
 - [Installation](#installation)
 - [Within python scDRS demo](#within-python-scdrs-demo)
+- [Make .gs file (CLI)](#make-gs-file-cli)
 - [Command line interface for scDRS score calculation](#command-line-interface-for-scdrs-score-calculation)
-- [Command line interface for scDRS downsteam applications](#command-line-interface-for-scdrs-downsteam-applications)
+- [scDRS downsteam applications (CLI)](#scdrs-downsteam-applications-cli)
 - [File formats](#file-formats)
   - [scDRS input files](#scdrs-input-files)
   - [scDRS output files](#scdrs-output-files)
@@ -77,6 +78,15 @@ The expected output is (see below for format of **.score.gz** file):
   | A17_B002755_B007347_S17.mm10-plus-7-0 | 5.379276  |  3.338063  | 0.003992 | 0.000800 |  3.096939   | 3.155926 |
   |    C22_B003856_S298_L004.mus-2-0-1    | 5.443514  |  4.537418  | 0.001996 | 0.000067 |  4.176120   | 3.820235 |
 
+# Make .gs file (CLI)
+- Input: space-delimited file with gene names in the first column, and the rest of columns as disease names and gene-level p-values or z-scores.
+- Output: weights gene set file used by scDRS.
+
+```sh
+scdrs make-gs \
+  --pval-file <pval-file> \ # replace this with --zscore-file <zscore-file> as needed
+  --out-file <out-file>
+```
 
 # Command line interface for scDRS score calculation 
 - Input: scRNA-seq data (**.h5ad** file) and gene set file (**.gs** file)
@@ -113,32 +123,35 @@ The expected output is (see below for format of **.score.gz** file):
   - `--flag_return_ctrl_norm_score` ("True"/"False") : if to return normalized control scores
   - `--out_folder` : output folder. Score files will be saved as `{out_folder}/{trait}.score.gz` (see below for file format)
 
-# Command line interface for scDRS downsteam applications 
+# scDRS downsteam applications (CLI)
 - Input: scRNA-seq data (**.h5ad** file), gene set file (**.gs** file), and scDRS full score files (**.full_score.gz** files)
 - Output: **{trait}.scdrs_ct.{cell_type}** file for cell type-level analyses (association and heterogeneity); **{trait}.scdrs_var** file for cell variable-disease association; **{trait}.scdrs_gene** file for disease gene prioritization.
-  ```sh
-  h5ad_file=your_scrnaseq_data
-  out_dir=your_output_folder
-  python compute_downstream.py \
-      --h5ad_file ${h5ad_file}.h5ad \
-      --score_file @.full_score.gz \
-      --cell_type cell_type \
-      --cell_variable causal_variable,non_causal_variable,covariate\
-      --flag_gene True\
-      --flag_filter False\
-      --flag_raw_count False\
-      --out_folder ${out_dir}
-  ```
-  
 
-  - --`h5ad_file` (**.h5ad** file) : scRNA-seq data
-  - --`score_file` (**.full_score.gz** files) : scDRS full score files; supporting use of "@" to match strings
-  - --`cell_type` (str) : cell type column (supporting multiple columns separated by comma); must be present in `adata.obs.columns`; used for cell type-disease association analyses (5% quantile as test statistic) and detecting association heterogeneity within cell type (Geary's C as test statistic)
-  - --`cell_variable` (str) : cell-level variable columns (supporting multiple columns separated by comma); must be present in `adata.obs.columns`; used for cell variable-disease association analyses (Pearson's correlation as test statistic)
-  - --`flag_gene` ("True"/"False") : if to correlate scDRS disease scores with gene expression
-  - --`flag_filter` ("True"/"False") : if to perform minimum filtering of cells and genes
-  - --`flag_raw_count` ("True"/"False") : if to perform normalization (size-factor + log1p)
-  - --`out_folder` : output folder. Score files will be saved as `{out_folder}/{trait}.scdrs_ct.{cell_type}` for cell type-level analyses (association and heterogeneity); `{out_folder}/{trait}.scdrs_var` file for cell variable-disease association; `{out_folder}/{trait}.scdrs_var.{trait}.scdrs_gene` file for disease gene prioritization. (see below for file format)
+```sh
+h5ad_file=your_scrnaseq_data
+out_dir=your_output_folder
+scdrs downstream \
+    --h5ad_file ${h5ad_file}.h5ad \
+    --score_file @.full_score.gz \
+    --group-analysis <group-vars> \
+    --flag_filter False \
+    --flag_raw_count False \
+    --out_folder ${out_dir}
+```
+
+The line of `--group-analysis <group-vars>` can be replaced with
+- `--corr-analysis <corr_vars>` for correlation analysis between scDRS scores with some covariates.
+- `--gene-analysis` for gene prioritization.
+
+These options corresponds to
+- --`h5ad_file` (**.h5ad** file) : scRNA-seq data
+- --`score_file` (**.full_score.gz** files) : scDRS full score files; supporting use of "@" to match strings
+- --`group_analysis` (str) : cell type column (supporting multiple columns separated by comma); must be present in `adata.obs.columns`; used for cell type-disease association analyses (5% quantile as test statistic) and detecting association heterogeneity within cell type (Geary's C as test statistic)
+- --`corr_analysis` (str) : cell-level variable columns (supporting multiple columns separated by comma); must be present in `adata.obs.columns`; used for cell variable-disease association analyses (Pearson's correlation as test statistic)
+- --`gene-analysis` ("True"/"False") : if to correlate scDRS disease scores with gene expression
+- --`flag_filter` ("True"/"False") : if to perform minimum filtering of cells and genes
+- --`flag_raw_count` ("True"/"False") : if to perform normalization (size-factor + log1p)
+- --`out_folder` : output folder. Score files will be saved as `{out_folder}/{trait}.scdrs_ct.{cell_type}` for cell type-level analyses (association and heterogeneity); `{out_folder}/{trait}.scdrs_var` file for cell variable-disease association; `{out_folder}/{trait}.scdrs_var.{trait}.scdrs_gene` file for disease gene prioritization. (see below for file format)
     
 
 # File formats

--- a/bin/scdrs
+++ b/bin/scdrs
@@ -6,11 +6,9 @@ import numpy as np
 from statsmodels.stats.multitest import multipletests
 import scdrs
 from typing import Dict, List
-from anndata import read_h5ad
 import scanpy as sc
 import time
 import os
-import fnmatch
 
 
 def compute_score():
@@ -163,8 +161,6 @@ def perform_downstream(
         Comma-seperated column names for variables representing groups
         (e.g., cell types or tissues)
     """
-    sys_start_time = time.time()
-
     # check arguments
     assert (
         (group_analysis is not None)
@@ -173,191 +169,58 @@ def perform_downstream(
     ) == 1, (
         "only one of `group_analysis`, `corr_analysis`, `gene_analyis` can be specified"
     )
-
-    # Load .h5ad file
-    adata = read_h5ad(h5ad_file)
-    if filter_data:
-        sc.pp.filter_cells(adata, min_genes=250)
-        sc.pp.filter_genes(adata, min_cells=50)
-    if raw_count:
-        sc.pp.normalize_per_cell(adata, counts_per_cell_after=1e4)
-        sc.pp.log1p(adata)
-    print(
-        "--h5ad_file loaded: n_cell=%d, n_gene=%d (sys_time=%0.1fs)"
-        % (adata.shape[0], adata.shape[1], time.time() - sys_start_time)
+    adata = scdrs.util.load_h5ad(
+        h5ad_file=h5ad_file, filter_data=filter_data, raw_count=raw_count
     )
+    dict_df_score = scdrs.util.load_drs_score(score_file)
 
-    # Load score file
-    score_file_pattern = score_file.split(os.path.sep)[-1]
-    score_dir = score_file.replace(os.path.sep + score_file_pattern, "")
-    score_file_list = [
-        x
-        for x in os.listdir(score_dir)
-        if fnmatch.fnmatch(x, score_file_pattern.replace("@", "*"))
-    ]
-    print("Infer score_dir=%s" % score_dir)
-    print("Find %s score_files: %s" % (len(score_file_list), ",".join(score_file_list)))
-    dic_score = {}
-    for score_file in score_file_list:
-        temp_df = pd.read_csv(
-            score_dir + os.path.sep + score_file, sep="\t", index_col=0
-        )
-        n_cell_overlap = len(set(adata.obs_names) & set(temp_df.index))
-        if n_cell_overlap < 0.1 * adata.shape[0]:
-            print(
-                "WARNING: %s skipped, %d/%d cells in adata"
-                % (score_file, n_cell_overlap, adata.shape[0])
-            )
-        else:
-            dic_score[score_file.replace(".full_score.gz", "")] = temp_df.copy()
-
-    print(
-        "--score_file loaded: n_trait=%d, (sys_time=%0.1fs)"
-        % (len(dic_score), time.time() - sys_start_time)
-    )
-    print("")
-
-    ###########################################################################################
-    ######                                  Computation                                  ######
-    ###########################################################################################
-
-    # preprocess arguments
-    group_list = []
-    var_list = []
+    # branch into different analysis
     if group_analysis is not None:
         if isinstance(group_analysis, str):
-            group_list.extend(group_analysis.split(","))
+            group_cols = group_analysis.split(",")
         elif isinstance(group_analysis, tuple):
-            group_list.extend([g for g in group_analysis])
+            group_cols = [g for g in group_analysis]
         else:
             raise ValueError("group_analysis should be a string or a tuple of strings")
-        if "connectivities" not in adata.obsp:
-            sc.pp.neighbors(adata, n_neighbors=10, n_pcs=40)
-            print(
-                "Compute connectivities with `sc.pp.neighbors`"
-                "because `connectivities` is not found in adata.obsp"
+        for trait in dict_df_score:
+            dict_df_res = scdrs.util.downstream_group_analysis(
+                adata=adata, df_drs=dict_df_score[trait], group_cols=group_cols
             )
-    elif corr_analysis is not None:
-        if isinstance(corr_analysis, str):
-            var_list.extend(corr_analysis.split(","))
-        elif isinstance(corr_analysis, tuple):
-            var_list.extend([v for v in corr_analysis])
-        else:
-            raise ValueError("corr_analysis should be a string or a tuple of strings")
-    elif gene_analysis is not None:
-        pass
-    else:
-        raise ValueError("No analysis specified")
-
-    # A separate file for each trait
-    for trait in dic_score.keys():
-        cell_list = sorted(set(adata.obs_names) & set(dic_score[trait].index))
-        control_list = [
-            x for x in dic_score[trait].columns if x.startswith("ctrl_norm_score")
-        ]
-        n_ctrl = len(control_list)
-        df_reg = adata.obs.loc[cell_list, group_list + var_list].copy()
-        df_reg = df_reg.join(
-            dic_score[trait].loc[cell_list, ["norm_score"] + control_list]
-        )
-        if group_analysis is not None:
-            # Cell type-disease analysis: association + heterogeneity
-            for ct_col in group_list:
-                ct_list = sorted(set(adata.obs[ct_col]))
-                col_list = [
-                    "n_cell",
-                    "n_ctrl",
-                    "assoc_mcp",
-                    "assoc_mcz",
-                    "hetero_mcp",
-                    "hetero_mcz",
-                ]
-                df_res = pd.DataFrame(index=ct_list, columns=col_list, dtype=np.float32)
-                # Basic info
-                for ct in ct_list:
-                    ct_cell_list = list(df_reg.index[df_reg[ct_col] == ct])
-                    df_res.loc[ct, ["n_cell", "n_ctrl"]] = [len(ct_cell_list), n_ctrl]
-                # Association
-                for ct in ct_list:
-                    ct_cell_list = list(df_reg.index[df_reg[ct_col] == ct])
-                    score_q95 = np.quantile(
-                        df_reg.loc[ct_cell_list, "norm_score"], 0.95
-                    )
-                    v_ctrl_score_q95 = np.quantile(
-                        df_reg.loc[ct_cell_list, control_list], 0.95, axis=0
-                    )
-                    mc_p = ((v_ctrl_score_q95 >= score_q95).sum() + 1) / (
-                        v_ctrl_score_q95.shape[0] + 1
-                    )
-                    mc_z = (
-                        score_q95 - v_ctrl_score_q95.mean()
-                    ) / v_ctrl_score_q95.std()
-                    df_res.loc[ct, ["assoc_mcp", "assoc_mcz"]] = [mc_p, mc_z]
-                # Heterogeneity
-                df_rls = scdrs.util.test_gearysc(adata, df_reg, groupby=ct_col)
-                for ct in ct_list:
-                    mc_p, mc_z = df_rls.loc[ct, ["pval", "zsc"]]
-                    df_res.loc[ct, ["hetero_mcp", "hetero_mcz"]] = [mc_p, mc_z]
-
-                df_res.to_csv(
+            for group_col in group_cols:
+                dict_df_res[group_col].to_csv(
                     os.path.join(
-                        out_folder, "%s.scdrs_ct.%s" % (trait, ct_col.replace(" ", "_"))
+                        out_folder,
+                        f"{trait}.scdrs_ct.{group_col.replace(' ', '_')}",
                     ),
                     sep="\t",
                     index=True,
                 )
-                print(
-                    "%s: cell type-level analysis with label=%s (sys_time=%0.1fs)"
-                    % (trait, ct_col, time.time() - sys_start_time)
-                )
-        elif corr_analysis is not None:
-            # Variable-disease correlation
-            if len(var_list) > 0:
-                col_list = ["n_ctrl", "corr_mcp", "corr_mcz"]
-                df_res = pd.DataFrame(
-                    index=var_list, columns=col_list, dtype=np.float32
-                )
-                for var_col in var_list:
-                    corr_ = np.corrcoef(df_reg[var_col], df_reg["norm_score"])[0, 1]
-                    v_corr_ = np.array(
-                        [
-                            np.corrcoef(
-                                df_reg[var_col], df_reg["ctrl_norm_score_%d" % x]
-                            )[0, 1]
-                            for x in np.arange(n_ctrl)
-                        ]
-                    )
-                    mc_p = ((v_corr_ >= corr_).sum() + 1) / (v_corr_.shape[0] + 1)
-                    mc_z = (corr_ - v_corr_.mean()) / v_corr_.std()
-                    df_res.loc[var_col] = [n_ctrl, mc_p, mc_z]
-                df_res.to_csv(
-                    os.path.join(out_folder, "%s.scdrs_var" % trait),
-                    sep="\t",
-                    index=True,
-                )
-                print(
-                    "%s: cell-level variable-disease correlation analysis (sys_time=%0.1fs)"
-                    % (trait, time.time() - sys_start_time)
-                )
-        elif gene_analysis is not None:
-            # Gene prioritization
-            mat_expr = adata[df_reg.index].X.copy()
-            v_corr = scdrs.method._pearson_corr(mat_expr, df_reg["norm_score"].values)
-            df_res = pd.DataFrame(
-                index=adata.var_names, columns=["CORR", "RANK"], dtype=np.float32
-            )
-            df_res["CORR"] = v_corr
-            df_res.sort_values("CORR", ascending=False, inplace=True)
-            df_res["RANK"] = np.arange(df_res.shape[0])
-            df_res.to_csv(
-                os.path.join(out_folder, "%s.scdrs_gene" % trait), sep="\t", index=True
-            )
-            print(
-                "%s: disease gene prioritization (sys_time=%0.1fs)"
-                % (trait, time.time() - sys_start_time)
-            )
+
+    elif corr_analysis is not None:
+        if isinstance(corr_analysis, str):
+            var_list = corr_analysis.split(",")
+        elif isinstance(corr_analysis, tuple):
+            var_list = [v for v in corr_analysis]
         else:
-            print("%s: no analysis" % trait)
+            raise ValueError("corr_analysis should be a string or a tuple of strings")
+        for trait in dict_df_score:
+            df_res = scdrs.util.downstream_corr_analysis(
+                adata=adata, df_drs=dict_df_score[trait], var_cols=var_list
+            )
+            df_res.to_csv(
+                os.path.join(out_folder, f"{trait}.scdrs_var"), sep="\t", index=True
+            )
+    elif gene_analysis is not None:
+        for trait in dict_df_score:
+            df_res = scdrs.util.downstream_gene_analysis(
+                adata=adata, df_drs=dict_df_score[trait]
+            )
+            # save results
+            df_res.to_csv(
+                os.path.join(out_folder, f"{trait}.scdrs_gene"), sep="\t", index=True
+            )
+    else:
+        raise ValueError("No analysis specified")
 
 
 if __name__ == "__main__":

--- a/bin/scdrs
+++ b/bin/scdrs
@@ -225,7 +225,12 @@ def downstream(
     group_list = []
     var_list = []
     if group_analysis is not None:
-        group_list.extend([g for g in group_analysis])
+        if isinstance(group_analysis, str):
+            group_list.extend(group_analysis.split(","))
+        elif isinstance(group_analysis, tuple):
+            group_list.extend([g for g in group_analysis])
+        else:
+            raise ValueError("group_analysis should be a string or a tuple of strings")
         if "connectivities" not in adata.obsp:
             sc.pp.neighbors(adata, n_neighbors=10, n_pcs=40)
             print(
@@ -233,7 +238,12 @@ def downstream(
                 "because `connectivities` is not found in adata.obsp"
             )
     elif corr_analysis is not None:
-        var_list.extend([v for v in corr_analysis])
+        if isinstance(corr_analysis, str):
+            var_list.extend(corr_analysis.split(","))
+        elif isinstance(corr_analysis, tuple):
+            var_list.extend([v for v in corr_analysis])
+        else:
+            raise ValueError("corr_analysis should be a string or a tuple of strings")
     elif gene_analysis is not None:
         pass
     else:

--- a/bin/scdrs
+++ b/bin/scdrs
@@ -13,7 +13,7 @@ import os
 import fnmatch
 
 
-def score():
+def compute_score():
     """
     CLI for scoring cell, e.g.,
     TODO: decide whether to move compute_score.py here
@@ -22,7 +22,7 @@ def score():
     pass
 
 
-def make_gs(
+def munge_gs(
     out: str,
     pval_file: str = None,
     zscore_file: str = None,
@@ -136,7 +136,7 @@ def make_gs(
     df_gs.to_csv(out, sep="\t", index=False)
 
 
-def downstream(
+def perform_downstream(
     h5ad_file: str,
     score_file: str,
     out_folder: str,

--- a/bin/scdrs
+++ b/bin/scdrs
@@ -5,6 +5,7 @@ import pandas as pd
 import numpy as np
 from statsmodels.stats.multitest import multipletests
 import scdrs
+from typing import Dict, List
 
 
 def score():
@@ -16,12 +17,10 @@ def score():
     pass
 
 
-def make_gs_weight(
-    src_path: str,
+def make_gs(
     out: str,
-    gene_col: str = "GENE",
-    pval_col: str = None,
-    zsc_col: str = None,
+    pval_file: str = None,
+    zscore_file: str = None,
     weight: str = "zscore",
     fdr: float = None,
     fwer: float = None,
@@ -29,23 +28,31 @@ def make_gs_weight(
     n_max: int = 1000,
 ):
     """
-    CLI for making gene set, convert a MAGMA result-like file to a gene set, e.g.,
+    CLI for making gene set, convert a MAGMA result-like file to a gene set.
+    
+    <src_file> is a space-delimited file with the following formats:
+    - The first column should corresponds to gene names
+    - For the one or more columns to follow, the header should be the disease name,
+        and the values should be the gene-level p-values.
 
-    using the following steps:
-    1. Read result, which is assumed to space-delimited, e.g., MAGMA result file
-    2. Find the gene ID column with `gene_col` and p-values
-        (either through `pval_col` or `zsc_col`)
-    3. Thresholding the number of genes using FDR or FWER
-    4. Then cap them between `n_min` and `n_max`
-    5. Write gene set to `out`
+    For example, <src_file> looks like
+
+        GENE    BMI    HEIGHT
+        OR4F5   0.001  0.01
+        DAZ3    0.01   0.001
+        ...
+    
+    This function make the gene weights with the following steps.
+    1. Read result, which is assumed to  e.g., MAGMA result file
+    2. Thresholding the number of genes using FDR or FWER
+    3. Then cap them between `n_min` and `n_max`
+    4. Write gene set to `out`
 
     Examples
     --------
     scdrs make-gs-weight \
-        --src-path <src_path> \
+        --pval-file <pval_file> \
         --out <out> \
-        --gene-col <gene_col> \
-        --pval-col <pval_col> \
         --zsc-col <zsc_col> \
         --weight <weight> \
         --fdr <fdr> \
@@ -53,61 +60,76 @@ def make_gs_weight(
         --n-min <n_min> \
         --n-max <n_max>
     """
-    # 1. Read result, which is assumed to space-delimited, e.g., MAGMA result file
-    df = pd.read_csv(src_path, delim_whitespace=True)
-
-    # 2. Find the gene ID column with `gene_col` and p-values
-    #    (either through `pval_col` or `zsc_col`)
-    assert gene_col in df.columns, f"Gene column {gene_col} not found in {src_path}"
-
-    assert (pval_col is None) or (
-        zsc_col is None
-    ), f"`pval_col` and `zsc_col` can not be both specified"
-
-    # if none of them is specified, infer the pval_col with "P"
-    if (pval_col is None) and (zsc_col is None):
-        pval_col = "P"
-
-    # calculate p-values
-    if pval_col is not None:
-        pval = df[pval_col].values
-    elif zsc_col is not None:
-        # single-sided gene-level p-value
-        pval = scdrs.util.zsc2pval(df[pval_col].values)
-
-    df_pval = pd.DataFrame({"GENE": df[gene_col].values, "P": pval}).dropna(axis=0)
-
-    # 3. Thresholding the number of genes using FDR or FWER (if specified)
-    #   and cap them between `n_min` and `n_max`
-
-    assert (fdr is None) or (
-        fwer is None
-    ), f"`fdr` and `fwer` can not be both specified"
-    if fwer is not None:
-        n_gene = multipletests(df_pval.P, method="bonferroni")[1] < fwer
-    elif fdr is not None:
-        n_gene = multipletests(df_pval.P, method="fdr_bh")[1] < fdr
+    # either pval_file or zscore_file should be provided
+    assert (pval_file is None) != (
+        zscore_file is None
+    ), "Either `pval_file` or `zscore_file` should be provided"
+    if zscore_file is not None:
+        # convert z-score to p-values
+        df_zscore = pd.read_csv(zscore_file, delim_whitespace=True)
+        df_pval = df_zscore.copy()
+        for col in df_pval.columns[1:]:
+            df_pval[col] = scdrs.util.zsc2pval(df_zscore[col])
     else:
-        # if none of them is specified, just use the n_max
-        n_gene = n_max
+        df_pval = pd.read_csv(pval_file, delim_whitespace=True)
 
-    # 4. cap them between `n_min` and `n_max`
-    n_gene = np.minimum(n_gene, n_max)
-    n_gene = np.maximum(n_gene, n_min)
+    gene_col = df_pval.columns[0]
+    trait_list = df_pval.columns[1:].values
 
-    # 5. use the top `n_gene` genes
-    df_gene = df_pval.sort_values("P").iloc[:n_gene, :].reset_index(drop=True)
+    dict_gene_weights: Dict[str, List] = {
+        "TRAIT": [],
+        "GENESET": [],
+    }
+    for trait in trait_list:
+        # some p-value can be NaN
+        df_trait_pval = df_pval[[gene_col, trait]].copy().dropna(axis=0)
 
-    if weight == "zscore":
-        df_gene["WEIGHT"] = scdrs.util.zsc2pval(df_gene.P)
-    elif weight == "uniform":
-        df_gene["WEIGHT"] = 1
-    else:
-        raise ValueError(f"Unknown weight {weight}")
+        assert np.all(
+            (0 <= df_trait_pval[trait].values) & (df_trait_pval[trait].values <= 1)
+        ), f"{trait}'s p-value are not between 0 and 1"
 
-    # 6. Write gene set to `out`
+        # Thresholding the number of genes using FDR or FWER (if specified)
+        #   and cap them between `n_min` and `n_max`
+        assert (fdr is None) or (
+            fwer is None
+        ), f"`fdr` and `fwer` can not be both specified"
+        if fwer is not None:
+            n_gene = (
+                multipletests(df_trait_pval[trait].values, method="bonferroni")[1]
+                < fwer
+            )
+        elif fdr is not None:
+            n_gene = (
+                multipletests(df_trait_pval[trait].values, method="fdr_bh")[1] < fdr
+            )
+        else:
+            # if none of them is specified, just use the n_max
+            n_gene = n_max
 
-    df_gene[["GENE", "WEIGHT"]].to_csv(out, sep="\t", index=False)
+        # 4. cap them between `n_min` and `n_max`
+        n_gene = np.minimum(n_gene, n_max)
+        n_gene = np.maximum(n_gene, n_min)
+
+        # use the `n_gene` with smallest p-value
+        df_trait_pval = (
+            df_trait_pval.sort_values(trait).iloc[:n_gene].reset_index(drop=True)
+        )
+        gene_list = df_trait_pval[gene_col].values
+        gene_pvals = df_trait_pval[trait].values
+        gene_pvals += 1e-16  # to avoid zero p-value
+        if weight == "zscore":
+            gene_weights = scdrs.util.pval2zsc(gene_pvals)
+        elif weight == "uniform":
+            gene_weights = np.ones(len(gene_list))
+        else:
+            raise ValueError(f"Unknown gene weight option {weight}")
+
+        dict_gene_weights["TRAIT"].append(trait)
+        dict_gene_weights["GENESET"].append(
+            ",".join([f"{g}:{w:.5g}" for g, w in zip(gene_list, gene_weights)])
+        )
+    df_gs = pd.DataFrame(dict_gene_weights)
+    df_gs.to_csv(out, sep="\t", index=False)
 
 
 def downstream():

--- a/bin/scdrs
+++ b/bin/scdrs
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+
+import fire
+import pandas as pd
+import numpy as np
+from statsmodels.stats.multitest import multipletests
+import scdrs
+
+
+def score():
+    """
+    CLI for scoring cell, e.g.,
+
+    scdrs score --h5ad-file <h5ad_file> ...
+    """
+    pass
+
+
+def make_gs_weight(
+    src_path: str,
+    out: str,
+    gene_col: str = "GENE",
+    pval_col: str = None,
+    zsc_col: str = None,
+    weight: str = "zscore",
+    fdr: float = None,
+    fwer: float = None,
+    n_min: int = 100,
+    n_max: int = 1000,
+):
+    """
+    CLI for making gene set, convert a MAGMA result-like file to a gene set, e.g.,
+
+    using the following steps:
+    1. Read result, which is assumed to space-delimited, e.g., MAGMA result file
+    2. Find the gene ID column with `gene_col` and p-values
+        (either through `pval_col` or `zsc_col`)
+    3. Thresholding the number of genes using FDR or FWER
+    4. Then cap them between `n_min` and `n_max`
+    5. Write gene set to `out`
+
+    Examples
+    --------
+    scdrs make-gs-weight \
+        --src-path <src_path> \
+        --out <out> \
+        --gene-col <gene_col> \
+        --pval-col <pval_col> \
+        --zsc-col <zsc_col> \
+        --weight <weight> \
+        --fdr <fdr> \
+        --fwer <fwer> \
+        --n-min <n_min> \
+        --n-max <n_max>
+    """
+    # 1. Read result, which is assumed to space-delimited, e.g., MAGMA result file
+    df = pd.read_csv(src_path, delim_whitespace=True)
+
+    # 2. Find the gene ID column with `gene_col` and p-values
+    #    (either through `pval_col` or `zsc_col`)
+    assert gene_col in df.columns, f"Gene column {gene_col} not found in {src_path}"
+
+    assert (pval_col is None) or (
+        zsc_col is None
+    ), f"`pval_col` and `zsc_col` can not be both specified"
+
+    # if none of them is specified, infer the pval_col with "P"
+    if (pval_col is None) and (zsc_col is None):
+        pval_col = "P"
+
+    # calculate p-values
+    if pval_col is not None:
+        pval = df[pval_col].values
+    elif zsc_col is not None:
+        # single-sided gene-level p-value
+        pval = scdrs.util.zsc2pval(df[pval_col].values)
+
+    df_pval = pd.DataFrame({"GENE": df[gene_col].values, "P": pval}).dropna(axis=0)
+
+    # 3. Thresholding the number of genes using FDR or FWER (if specified)
+    #   and cap them between `n_min` and `n_max`
+
+    assert (fdr is None) or (
+        fwer is None
+    ), f"`fdr` and `fwer` can not be both specified"
+    if fwer is not None:
+        n_gene = multipletests(df_pval.P, method="bonferroni")[1] < fwer
+    elif fdr is not None:
+        n_gene = multipletests(df_pval.P, method="fdr_bh")[1] < fdr
+    else:
+        # if none of them is specified, just use the n_max
+        n_gene = n_max
+
+    # 4. cap them between `n_min` and `n_max`
+    n_gene = np.minimum(n_gene, n_max)
+    n_gene = np.maximum(n_gene, n_min)
+
+    # 5. use the top `n_gene` genes
+    df_gene = df_pval.sort_values("P").iloc[:n_gene, :].reset_index(drop=True)
+
+    if weight == "zscore":
+        df_gene["WEIGHT"] = scdrs.util.zsc2pval(df_gene.P)
+    elif weight == "uniform":
+        df_gene["WEIGHT"] = 1
+    else:
+        raise ValueError(f"Unknown weight {weight}")
+
+    # 6. Write gene set to `out`
+
+    df_gene[["GENE", "WEIGHT"]].to_csv(out, sep="\t", index=False)
+
+
+def downstream():
+    """
+    CLI for downstream analysis, e.g.,
+
+    scdrs downstream --h5ad-file <h5ad_file> ...
+    """
+    pass
+
+
+if __name__ == "__main__":
+    fire.Fire()

--- a/bin/scdrs
+++ b/bin/scdrs
@@ -8,15 +8,222 @@ import scdrs
 from typing import Dict, List
 import scanpy as sc
 import os
+import time
 
 
-def compute_score():
+VERSION = "beta"
+
+
+def get_cli_head():
+    MASTHEAD = "******************************************************************************\n"
+    MASTHEAD += "* Single-cell disease relevance score (scDRS)\n"
+    MASTHEAD += "* Version %s\n" % VERSION
+    MASTHEAD += "* Martin Jinye Zhang and Kangcheng Hou\n"
+    MASTHEAD += "* HSPH / Broad Institute / UCLA\n"
+    MASTHEAD += "* MIT License\n"
+    MASTHEAD += "******************************************************************************\n"
+    return MASTHEAD
+
+
+def compute_score(
+    h5ad_file: str,
+    h5ad_species: str,
+    gs_file: str,
+    gs_species: str,
+    out_folder: str,
+    cov_file: str = None,
+    ctrl_match_opt: str = "mean_var",
+    weight_opt: str = "vs",
+    flag_filter: bool = True,
+    flag_raw_count: bool = True,
+    n_ctrl: int = 1000,
+    flag_return_ctrl_raw_score: bool = False,
+    flag_return_ctrl_norm_score: bool = True,
+):
     """
-    CLI for scoring cell, e.g.,
-    TODO: decide whether to move compute_score.py here
-    scdrs score --h5ad-file <h5ad_file> ...
+    Single-cell disease relevance score (scDRS)
+
+    Parameters
+    ----------
+    h5ad_file : str
+        Path to the h5ad file.
+    h5ad_species : str
+        Species of the h5ad file. one of [hsapiens, mmusculus]
+    gs_file : str
+        Path to the gs file.
+    gs_species : str
+        Species of the gs file. one of [hsapiens, mmusculus]
+    out_folder : str
+        Path to the output folder. Save file at <out_folder>/<trait>.score.gz
+    cov_file : str, optional
+        Path to the covariate file. The default is None.
+    ctrl_match_opt : str, optional
+        Control matching option. The default is "mean_var".
+    weight_opt : str, optional
+        Weighting option. The default is "vs".
+    flag_filter : bool, optional
+        Flag on whether to apply cell and gene filters to the h5ad_file data.
+        The default is True.
+    flag_raw_count : bool, optional
+        Flag on whether to apply size factor normalization and log1p transformation.
+        The default is True.
+    n_ctrl : int, optional
+        Number of control gene sets. The default is 1000.
+    flag_return_ctrl_raw_score : bool, optional
+        Flag to return raw control scores. The default is False.
+    flag_return_ctrl_norm_score : bool, optional
+        Flag to return the normalized control scores. The default is True.
     """
-    pass
+
+    sys_start_time = time.time()
+
+    ###########################################################################################
+    ######                                    Parse Options                              ######
+    ###########################################################################################
+    H5AD_FILE = h5ad_file
+    H5AD_SPECIES = h5ad_species
+    COV_FILE = cov_file
+    GS_FILE = gs_file
+    GS_SPECIES = gs_species
+    CTRL_MATCH_OPT = ctrl_match_opt
+    WEIGHT_OPT = weight_opt
+    FLAG_FILTER = flag_filter == "True"
+    FLAG_RAW_COUNT = flag_raw_count == "True"
+    N_CTRL = n_ctrl
+    FLAG_RETURN_CTRL_RAW_SCORE = flag_return_ctrl_raw_score
+    FLAG_RETURN_CTRL_NORM_SCORE = flag_return_ctrl_norm_score
+    OUT_FOLDER = out_folder
+
+    if H5AD_SPECIES != GS_SPECIES:
+        H5AD_SPECIES = scdrs.util.convert_species_name(H5AD_SPECIES)
+        GS_SPECIES = scdrs.util.convert_species_name(GS_SPECIES)
+
+    header = get_cli_head()
+    header += "Call: scdrs compute-score \\\n"
+    header += "--h5ad_file %s\\\n" % H5AD_FILE
+    header += "--h5ad_species %s\\\n" % H5AD_SPECIES
+    header += "--cov_file %s\\\n" % COV_FILE
+    header += "--gs_file %s\\\n" % GS_FILE
+    header += "--gs_species %s\\\n" % GS_SPECIES
+    header += "--ctrl_match_opt %s\\\n" % CTRL_MATCH_OPT
+    header += "--weight_opt %s\\\n" % WEIGHT_OPT
+    header += "--flag_filter %s\\\n" % FLAG_FILTER
+    header += "--flag_raw_count %s\\\n" % FLAG_RAW_COUNT
+    header += "--n_ctrl %d\\\n" % N_CTRL
+    header += "--flag_return_ctrl_raw_score %s\\\n" % FLAG_RETURN_CTRL_RAW_SCORE
+    header += "--flag_return_ctrl_norm_score %s\\\n" % FLAG_RETURN_CTRL_NORM_SCORE
+    header += "--out_folder %s\n" % OUT_FOLDER
+    print(header)
+
+    # Check options
+    if H5AD_SPECIES != GS_SPECIES:
+        if H5AD_SPECIES not in ["mmusculus", "hsapiens"]:
+            raise ValueError(
+                "--h5ad_species needs to be one of [mmusculus, hsapiens] "
+                "unless --h5ad_species==--gs_species"
+            )
+        if GS_SPECIES not in ["mmusculus", "hsapiens"]:
+            raise ValueError(
+                "--gs_species needs to be one of [mmusculus, hsapiens] "
+                "unless --h5ad_species==--gs_species"
+            )
+    if CTRL_MATCH_OPT not in ["mean", "mean_var"]:
+        raise ValueError("--ctrl_match_opt needs to be one of [mean, mean_var]")
+    if WEIGHT_OPT not in ["uniform", "vs", "inv_std", "od"]:
+        raise ValueError("--weight_opt needs to be one of [uniform, vs, inv_std, od]")
+
+    ###########################################################################################
+    ######                                     Load data                                 ######
+    ###########################################################################################
+    print("Load data:")
+
+    # Load .h5ad file
+    adata = scdrs.util.load_h5ad(
+        H5AD_FILE, flag_filter_data=FLAG_FILTER, flag_raw_count=FLAG_RAW_COUNT
+    )
+
+    print(
+        "--h5ad_file loaded: n_cell=%d, n_gene=%d (sys_time=%0.1fs)"
+        % (adata.shape[0], adata.shape[1], time.time() - sys_start_time)
+    )
+
+    # Load .cov file and regress out covariates
+    if COV_FILE is not None:
+        df_cov = pd.read_csv(COV_FILE, sep="\t", index_col=0)
+    else:
+        df_cov = None
+
+    # Load .gs file, convert species if needed and merge with adata.var_names
+    dict_gs = scdrs.util.load_gs(
+        GS_FILE,
+        src_species=GS_SPECIES,
+        dst_species=H5AD_SPECIES,
+        to_intersect=adata.var_names,
+    )
+
+    print(
+        "--gs_file loaded: n_geneset=%d (sys_time=%0.1fs)"
+        % (len(dict_gs), time.time() - sys_start_time)
+    )
+
+    ###########################################################################################
+    ######                                  Computation                                  ######
+    ###########################################################################################
+
+    # Preprocess
+    scdrs.preprocess(adata, cov=df_cov, n_mean_bin=20, n_var_bin=20, copy=False)
+
+    # Compute score
+    print("Compute score:")
+    for trait in dict_gs:
+        gene_list, gene_weights = dict_gs[trait]
+        if len(gene_list) < 10:
+            print(
+                "trait=%s: skipped due to small size (n_gene=%d, sys_time=%0.1fs)"
+                % (trait, len(gene_list), time.time() - sys_start_time)
+            )
+            continue
+
+        df_res = scdrs.score_cell(
+            adata,
+            gene_list,
+            gene_weight=gene_weights,
+            ctrl_match_key=CTRL_MATCH_OPT,
+            n_ctrl=N_CTRL,
+            weight_opt=WEIGHT_OPT,
+            return_ctrl_raw_score=FLAG_RETURN_CTRL_RAW_SCORE,
+            return_ctrl_norm_score=FLAG_RETURN_CTRL_NORM_SCORE,
+            verbose=False,
+        )
+
+        df_res.iloc[:, 0:6].to_csv(
+            os.path.join(OUT_FOLDER, "%s.score.gz" % trait),
+            sep="\t",
+            index=True,
+            compression="gzip",
+        )
+        if FLAG_RETURN_CTRL_RAW_SCORE | FLAG_RETURN_CTRL_NORM_SCORE:
+            df_res.to_csv(
+                os.path.join(OUT_FOLDER, "%s.full_score.gz" % trait),
+                sep="\t",
+                index=True,
+                compression="gzip",
+            )
+        v_fdr = multipletests(df_res["pval"].values, method="fdr_bh")[1]
+        n_rej_01 = (v_fdr < 0.1).sum()
+        n_rej_02 = (v_fdr < 0.2).sum()
+        print(
+            "Gene set %s (n_gene=%d): %d/%d FDR<0.1 cells, %d/%d FDR<0.2 cells (sys_time=%0.1fs)"
+            % (
+                trait,
+                len(gene_list),
+                n_rej_01,
+                df_res.shape[0],
+                n_rej_02,
+                df_res.shape[0],
+                time.time() - sys_start_time,
+            )
+        )
 
 
 def munge_gs(

--- a/bin/scdrs
+++ b/bin/scdrs
@@ -6,12 +6,17 @@ import numpy as np
 from statsmodels.stats.multitest import multipletests
 import scdrs
 from typing import Dict, List
+from anndata import read_h5ad
+import scanpy as sc
+import time
+import os
+import fnmatch
 
 
 def score():
     """
     CLI for scoring cell, e.g.,
-
+    TODO: decide whether to move compute_score.py here
     scdrs score --h5ad-file <h5ad_file> ...
     """
     pass
@@ -50,10 +55,9 @@ def make_gs(
 
     Examples
     --------
-    scdrs make-gs-weight \
+    scdrs make-gs \
         --pval-file <pval_file> \
         --out <out> \
-        --zsc-col <zsc_col> \
         --weight <weight> \
         --fdr <fdr> \
         --fwer <fwer> \
@@ -132,13 +136,218 @@ def make_gs(
     df_gs.to_csv(out, sep="\t", index=False)
 
 
-def downstream():
+def downstream(
+    h5ad_file: str,
+    score_file: str,
+    out_folder: str,
+    group_analysis: str = None,
+    corr_analysis: str = None,
+    gene_analysis: str = None,
+    filter_data: bool = False,
+    raw_count: bool = True,
+):
     """
-    CLI for downstream analysis, e.g.,
+    CLI for group-level analysis, e.g.,
 
-    scdrs downstream --h5ad-file <h5ad_file> ...
+    scdrs group-analysis --h5ad-file <h5ad_file> ...
+
+    Parameters
+    ----------
+    h5ad_file: str
+        Path to the h5ad file
+    score_file: str
+        Path to the score file
+    out_folder: str
+        Path to the output folder
+    group_list: str
+        Comma-seperated column names for variables representing groups
+        (e.g., cell types or tissues)
     """
-    pass
+    sys_start_time = time.time()
+
+    # check arguments
+    assert (
+        (group_analysis is not None)
+        + (corr_analysis is not None)
+        + (gene_analysis is not None)
+    ) == 1, (
+        "only one of `group_analysis`, `corr_analysis`, `gene_analyis` can be specified"
+    )
+
+    # Load .h5ad file
+    adata = read_h5ad(h5ad_file)
+    if filter_data:
+        sc.pp.filter_cells(adata, min_genes=250)
+        sc.pp.filter_genes(adata, min_cells=50)
+    if raw_count:
+        sc.pp.normalize_per_cell(adata, counts_per_cell_after=1e4)
+        sc.pp.log1p(adata)
+    print(
+        "--h5ad_file loaded: n_cell=%d, n_gene=%d (sys_time=%0.1fs)"
+        % (adata.shape[0], adata.shape[1], time.time() - sys_start_time)
+    )
+
+    # Load score file
+    score_file_pattern = score_file.split(os.path.sep)[-1]
+    score_dir = score_file.replace(os.path.sep + score_file_pattern, "")
+    score_file_list = [
+        x
+        for x in os.listdir(score_dir)
+        if fnmatch.fnmatch(x, score_file_pattern.replace("@", "*"))
+    ]
+    print("Infer score_dir=%s" % score_dir)
+    print("Find %s score_files: %s" % (len(score_file_list), ",".join(score_file_list)))
+    dic_score = {}
+    for score_file in score_file_list:
+        temp_df = pd.read_csv(
+            score_dir + os.path.sep + score_file, sep="\t", index_col=0
+        )
+        n_cell_overlap = len(set(adata.obs_names) & set(temp_df.index))
+        if n_cell_overlap < 0.1 * adata.shape[0]:
+            print(
+                "WARNING: %s skipped, %d/%d cells in adata"
+                % (score_file, n_cell_overlap, adata.shape[0])
+            )
+        else:
+            dic_score[score_file.replace(".full_score.gz", "")] = temp_df.copy()
+
+    print(
+        "--score_file loaded: n_trait=%d, (sys_time=%0.1fs)"
+        % (len(dic_score), time.time() - sys_start_time)
+    )
+    print("")
+
+    ###########################################################################################
+    ######                                  Computation                                  ######
+    ###########################################################################################
+
+    # preprocess arguments
+    group_list = []
+    var_list = []
+    if group_analysis is not None:
+        group_list.extend([g for g in group_analysis])
+        if "connectivities" not in adata.obsp:
+            sc.pp.neighbors(adata, n_neighbors=10, n_pcs=40)
+            print(
+                "Compute connectivities with `sc.pp.neighbors`"
+                "because `connectivities` is not found in adata.obsp"
+            )
+    elif corr_analysis is not None:
+        var_list.extend([v for v in corr_analysis])
+    elif gene_analysis is not None:
+        pass
+    else:
+        raise ValueError("No analysis specified")
+
+    # A separate file for each trait
+    for trait in dic_score.keys():
+        cell_list = sorted(set(adata.obs_names) & set(dic_score[trait].index))
+        control_list = [
+            x for x in dic_score[trait].columns if x.startswith("ctrl_norm_score")
+        ]
+        n_ctrl = len(control_list)
+        df_reg = adata.obs.loc[cell_list, group_list + var_list].copy()
+        df_reg = df_reg.join(
+            dic_score[trait].loc[cell_list, ["norm_score"] + control_list]
+        )
+        if group_analysis is not None:
+            # Cell type-disease analysis: association + heterogeneity
+            for ct_col in group_list:
+                ct_list = sorted(set(adata.obs[ct_col]))
+                col_list = [
+                    "n_cell",
+                    "n_ctrl",
+                    "assoc_mcp",
+                    "assoc_mcz",
+                    "hetero_mcp",
+                    "hetero_mcz",
+                ]
+                df_res = pd.DataFrame(index=ct_list, columns=col_list, dtype=np.float32)
+                # Basic info
+                for ct in ct_list:
+                    ct_cell_list = list(df_reg.index[df_reg[ct_col] == ct])
+                    df_res.loc[ct, ["n_cell", "n_ctrl"]] = [len(ct_cell_list), n_ctrl]
+                # Association
+                for ct in ct_list:
+                    ct_cell_list = list(df_reg.index[df_reg[ct_col] == ct])
+                    score_q95 = np.quantile(
+                        df_reg.loc[ct_cell_list, "norm_score"], 0.95
+                    )
+                    v_ctrl_score_q95 = np.quantile(
+                        df_reg.loc[ct_cell_list, control_list], 0.95, axis=0
+                    )
+                    mc_p = ((v_ctrl_score_q95 >= score_q95).sum() + 1) / (
+                        v_ctrl_score_q95.shape[0] + 1
+                    )
+                    mc_z = (
+                        score_q95 - v_ctrl_score_q95.mean()
+                    ) / v_ctrl_score_q95.std()
+                    df_res.loc[ct, ["assoc_mcp", "assoc_mcz"]] = [mc_p, mc_z]
+                # Heterogeneity
+                df_rls = scdrs.util.test_gearysc(adata, df_reg, groupby=ct_col)
+                for ct in ct_list:
+                    mc_p, mc_z = df_rls.loc[ct, ["pval", "zsc"]]
+                    df_res.loc[ct, ["hetero_mcp", "hetero_mcz"]] = [mc_p, mc_z]
+
+                df_res.to_csv(
+                    os.path.join(
+                        out_folder, "%s.scdrs_ct.%s" % (trait, ct_col.replace(" ", "_"))
+                    ),
+                    sep="\t",
+                    index=True,
+                )
+                print(
+                    "%s: cell type-level analysis with label=%s (sys_time=%0.1fs)"
+                    % (trait, ct_col, time.time() - sys_start_time)
+                )
+        elif corr_analysis is not None:
+            # Variable-disease correlation
+            if len(var_list) > 0:
+                col_list = ["n_ctrl", "corr_mcp", "corr_mcz"]
+                df_res = pd.DataFrame(
+                    index=var_list, columns=col_list, dtype=np.float32
+                )
+                for var_col in var_list:
+                    corr_ = np.corrcoef(df_reg[var_col], df_reg["norm_score"])[0, 1]
+                    v_corr_ = np.array(
+                        [
+                            np.corrcoef(
+                                df_reg[var_col], df_reg["ctrl_norm_score_%d" % x]
+                            )[0, 1]
+                            for x in np.arange(n_ctrl)
+                        ]
+                    )
+                    mc_p = ((v_corr_ >= corr_).sum() + 1) / (v_corr_.shape[0] + 1)
+                    mc_z = (corr_ - v_corr_.mean()) / v_corr_.std()
+                    df_res.loc[var_col] = [n_ctrl, mc_p, mc_z]
+                df_res.to_csv(
+                    os.path.join(out_folder, "%s.scdrs_var" % trait),
+                    sep="\t",
+                    index=True,
+                )
+                print(
+                    "%s: cell-level variable-disease correlation analysis (sys_time=%0.1fs)"
+                    % (trait, time.time() - sys_start_time)
+                )
+        elif gene_analysis is not None:
+            # Gene prioritization
+            mat_expr = adata[df_reg.index].X.copy()
+            v_corr = scdrs.method._pearson_corr(mat_expr, df_reg["norm_score"].values)
+            df_res = pd.DataFrame(
+                index=adata.var_names, columns=["CORR", "RANK"], dtype=np.float32
+            )
+            df_res["CORR"] = v_corr
+            df_res.sort_values("CORR", ascending=False, inplace=True)
+            df_res["RANK"] = np.arange(df_res.shape[0])
+            df_res.to_csv(
+                os.path.join(out_folder, "%s.scdrs_gene" % trait), sep="\t", index=True
+            )
+            print(
+                "%s: disease gene prioritization (sys_time=%0.1fs)"
+                % (trait, time.time() - sys_start_time)
+            )
+        else:
+            print("%s: no analysis" % trait)
 
 
 if __name__ == "__main__":

--- a/bin/scdrs
+++ b/bin/scdrs
@@ -7,7 +7,6 @@ from statsmodels.stats.multitest import multipletests
 import scdrs
 from typing import Dict, List
 import scanpy as sc
-import time
 import os
 
 
@@ -141,8 +140,8 @@ def perform_downstream(
     group_analysis: str = None,
     corr_analysis: str = None,
     gene_analysis: str = None,
-    filter_data: bool = False,
-    raw_count: bool = True,
+    flag_filter_data: bool = False,
+    flag_raw_count: bool = True,
 ):
     """
     CLI for group-level analysis, e.g.,
@@ -157,10 +156,22 @@ def perform_downstream(
         Path to the score file
     out_folder: str
         Path to the output folder
-    group_list: str
-        Comma-seperated column names for variables representing groups
+    group_analysis: str
+        Comma-seperated column names for variables in `adata` representing groups
         (e.g., cell types or tissues)
+    corr_analysis: str
+        Comma-seperated column names for variables in `adata` representing variables of
+        interest (e.g., age, sex) to correlate to scDRS scores
+    gene_analysis: str
+        Flag to perform the gene prioritization by correlating gene expression with scDRS
+        scores. No parameters are needed. Specify by `--gene-analysis`
+    flag_filter_data: bool
+        whether to filter the data based on the scDRS scores. Default is False.
+    flag_raw_count: bool
+        whether to use raw count or normalized count for downstream analysis.
+        Default is True.
     """
+
     # check arguments
     assert (
         (group_analysis is not None)
@@ -169,13 +180,18 @@ def perform_downstream(
     ) == 1, (
         "only one of `group_analysis`, `corr_analysis`, `gene_analyis` can be specified"
     )
+    # load h5ad file and score files
     adata = scdrs.util.load_h5ad(
-        h5ad_file=h5ad_file, filter_data=filter_data, raw_count=raw_count
+        h5ad_file=h5ad_file,
+        flag_filter_data=flag_filter_data,
+        flag_raw_count=flag_raw_count,
     )
     dict_df_score = scdrs.util.load_drs_score(score_file)
 
     # branch into different analysis
     if group_analysis is not None:
+        # `group_analysis` can be either List[str] or str
+        # make group_cols a list
         if isinstance(group_analysis, str):
             group_cols = group_analysis.split(",")
         elif isinstance(group_analysis, tuple):
@@ -197,19 +213,22 @@ def perform_downstream(
                 )
 
     elif corr_analysis is not None:
+        # `corr_analysis` can be either List[str] or str
+        # make group_cols a list
         if isinstance(corr_analysis, str):
-            var_list = corr_analysis.split(",")
+            var_cols = corr_analysis.split(",")
         elif isinstance(corr_analysis, tuple):
-            var_list = [v for v in corr_analysis]
+            var_cols = [v for v in corr_analysis]
         else:
             raise ValueError("corr_analysis should be a string or a tuple of strings")
         for trait in dict_df_score:
             df_res = scdrs.util.downstream_corr_analysis(
-                adata=adata, df_drs=dict_df_score[trait], var_cols=var_list
+                adata=adata, df_drs=dict_df_score[trait], var_cols=var_cols
             )
             df_res.to_csv(
                 os.path.join(out_folder, f"{trait}.scdrs_var"), sep="\t", index=True
             )
+
     elif gene_analysis is not None:
         for trait in dict_df_score:
             df_res = scdrs.util.downstream_gene_analysis(
@@ -219,6 +238,7 @@ def perform_downstream(
             df_res.to_csv(
                 os.path.join(out_folder, f"{trait}.scdrs_gene"), sep="\t", index=True
             )
+
     else:
         raise ValueError("No analysis specified")
 

--- a/scdrs/util.py
+++ b/scdrs/util.py
@@ -20,6 +20,14 @@ def check_import():
     return
 
 
+def convert_species_name(species):
+    if species in ["Mouse", "mouse", "Mus_musculus", "mus_musculus", "mmusculus"]:
+        return "mmusculus"
+    if species in ["Human", "human", "Homo_sapiens", "homo_sapiens", "hsapiens"]:
+        return "hsapiens"
+    raise ValueError("species name %s not supported" % species)
+
+
 def load_h5ad(
     h5ad_file: str, flag_filter_data: bool = False, flag_raw_count: bool = True
 ) -> anndata.AnnData:

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,9 @@ setuptools.setup(
         "pandas",
         "statsmodels",
         "pytest",
+        "fire",
+    ],
+    scripts=[
+        "bin/scdrs",
     ],
 )

--- a/tests/test_downstream.sh
+++ b/tests/test_downstream.sh
@@ -1,0 +1,41 @@
+H5AD_FILE=../scdrs/data/toydata_mouse.h5ad
+OUT_FOLDER=./
+
+# existing way
+SCORE_FILE=../scdrs/data/res/@.full_score.gz
+python3 ../compute_downstream.py \
+    --h5ad_file $H5AD_FILE \
+    --score_file $SCORE_FILE \
+    --cell_type cell_type \
+    --cell_variable causal_variable,non_causal_variable,covariate \
+    --flag_gene True \
+    --flag_filter False \
+    --flag_raw_count False \
+    --out_folder $OUT_FOLDER
+
+# group analysis
+scdrs downstream \
+    --h5ad_file $H5AD_FILE \
+    --score-file $SCORE_FILE \
+    --group-analysis cell_type \
+    --out-folder cli/ \
+    --filter-data False \
+    --raw-count False
+
+# correlation analysis
+scdrs downstream \
+    --h5ad_file $H5AD_FILE \
+    --score-file $SCORE_FILE \
+    --corr-analysis causal_variable,non_causal_variable,covariate \
+    --out-folder cli/ \
+    --filter-data False \
+    --raw-count False
+
+# gene analysis
+scdrs downstream \
+    --h5ad_file $H5AD_FILE \
+    --score-file $SCORE_FILE \
+    --gene-analysis \
+    --out-folder cli/ \
+    --filter-data False \
+    --raw-count False

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -56,3 +56,46 @@ def test_score_cell():
     df_ref_res = pd.read_csv(REF_COV_FILE, sep="\t", index_col=0)
     compare_score_file(df_res, df_ref_res)
     tmp_dir.cleanup()
+
+
+def test_downstream():
+
+    # Load toy data
+    ROOT_DIR = scdrs.__path__[0]
+    H5AD_FILE = os.path.join(ROOT_DIR, "data/toydata_mouse.h5ad")
+    SCORE_FILE = os.path.join(ROOT_DIR, "data/res/@.full_score.gz")
+    REF_RES_DIR = os.path.join(ROOT_DIR, "data/res")
+
+    import tempfile
+
+    tmp_dir = tempfile.TemporaryDirectory()
+    tmp_dir_path = tmp_dir.name
+    tmp_dir_path = "/Users/kangchenghou/work/scDRS/tests/tmp"
+    for task in [
+        "--group-analysis cell_type",
+        "--corr-analysis causal_variable,non_causal_variable,covariate",
+        "--gene-analysis",
+    ]:
+        # call scdrs downstream
+        cmds = [
+            f"scdrs downstream",
+            f"--h5ad_file {H5AD_FILE}",
+            f"--score-file {SCORE_FILE}",
+            task,
+            "--filter-data False",
+            "--raw-count False",
+            f"--out_folder {tmp_dir_path}",
+        ]
+        subprocess.check_call(" ".join(cmds), shell=True)
+
+    # check consistency between computed results and reference results
+
+    for prefix in ["toydata_gs_human", "toydata_gs_mouse"]:
+        for suffix in ["scdrs_ct.cell_type", "scdrs_gene", "scdrs_var"]:
+            res_path = os.path.join(tmp_dir_path, f"{prefix}.{suffix}")
+            ref_res_path = os.path.join(REF_RES_DIR, f"{prefix}.{suffix}")
+            df_res = pd.read_csv(res_path, sep="\t", index_col=0)
+            df_ref_rs = pd.read_csv(ref_res_path, sep="\t", index_col=0)
+            assert np.allclose(df_res.values, df_ref_rs.values)
+
+    tmp_dir.cleanup()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -81,8 +81,8 @@ def test_downstream():
             f"--h5ad_file {H5AD_FILE}",
             f"--score-file {SCORE_FILE}",
             task,
-            "--filter-data False",
-            "--raw-count False",
+            "--flag-filter-data False",
+            "--flag-raw-count False",
             f"--out_folder {tmp_dir_path}",
         ]
         subprocess.check_call(" ".join(cmds), shell=True)
@@ -94,7 +94,12 @@ def test_downstream():
             res_path = os.path.join(tmp_dir_path, f"{prefix}.{suffix}")
             ref_res_path = os.path.join(REF_RES_DIR, f"{prefix}.{suffix}")
             df_res = pd.read_csv(res_path, sep="\t", index_col=0)
-            df_ref_rs = pd.read_csv(ref_res_path, sep="\t", index_col=0)
-            assert np.allclose(df_res.values, df_ref_rs.values)
+            df_ref_res = pd.read_csv(ref_res_path, sep="\t", index_col=0)
+            # only test common columns between `df_res` and `df_ref_res`
+            common_cols = set(df_res.columns) & set(df_ref_res.columns)
+            assert np.allclose(
+                df_res[common_cols].values, df_ref_res[common_cols].values
+            )
+            print(df_res)
 
     tmp_dir.cleanup()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -77,7 +77,7 @@ def test_downstream():
     ]:
         # call scdrs downstream
         cmds = [
-            f"scdrs downstream",
+            f"scdrs perform-downstream",
             f"--h5ad_file {H5AD_FILE}",
             f"--score-file {SCORE_FILE}",
             task,

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -70,7 +70,6 @@ def test_downstream():
 
     tmp_dir = tempfile.TemporaryDirectory()
     tmp_dir_path = tmp_dir.name
-    tmp_dir_path = "/Users/kangchenghou/work/scDRS/tests/tmp"
     for task in [
         "--group-analysis cell_type",
         "--corr-analysis causal_variable,non_causal_variable,covariate",

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -58,6 +58,60 @@ def test_score_cell():
     tmp_dir.cleanup()
 
 
+def test_score_cell2():
+    """
+    New `scdrs compute-score` test
+    """
+    # Load toy data
+    ROOT_DIR = scdrs.__path__[0]
+    H5AD_FILE = os.path.join(ROOT_DIR, "data/toydata_mouse.h5ad")
+    COV_FILE = os.path.join(ROOT_DIR, "data/toydata_mouse.cov")
+    assert os.path.exists(H5AD_FILE), "built-in data toydata_mouse.h5ad missing"
+    assert os.path.exists(COV_FILE), "built-in data toydata_mouse.cov missing"
+
+    import tempfile
+
+    tmp_dir = tempfile.TemporaryDirectory()
+    tmp_dir_path = tmp_dir.name
+    dict_df_score = {}
+    for gs_species in ["human", "mouse"]:
+        gs_file = os.path.join(ROOT_DIR, f"data/toydata_{gs_species}.gs")
+        # call compute_score.py
+        cmds = [
+            f"scdrs compute-score",
+            f"--h5ad_file {H5AD_FILE}",
+            "--h5ad_species mouse",
+            f"--gs_file {gs_file}",
+            f"--gs_species {gs_species}",
+            f"--cov_file {COV_FILE}",
+            "--ctrl_match_opt mean_var",
+            "--n_ctrl 20",
+            "--flag_filter False",
+            "--weight_opt vs",
+            "--flag_raw_count False",
+            "--flag_return_ctrl_raw_score False",
+            "--flag_return_ctrl_norm_score False",
+            f"--out_folder {tmp_dir_path}",
+        ]
+        subprocess.check_call(" ".join(cmds), shell=True)
+        dict_df_score[gs_species] = pd.read_csv(
+            os.path.join(tmp_dir_path, f"toydata_gs_{gs_species}.score.gz"),
+            sep="\t",
+            index_col=0,
+        )
+    # consistency between human and mouse
+    assert np.all(dict_df_score["mouse"].pval == dict_df_score["human"].pval)
+
+    df_res = dict_df_score["mouse"]
+
+    REF_COV_FILE = os.path.join(
+        ROOT_DIR, "data/toydata_gs_mouse.ref_Ctrl20_CovConstCovariate.score.gz"
+    )
+    df_ref_res = pd.read_csv(REF_COV_FILE, sep="\t", index_col=0)
+    compare_score_file(df_res, df_ref_res)
+    tmp_dir.cleanup()
+
+
 def test_downstream():
 
     # Load toy data


### PR DESCRIPTION
### An updated command line interface with functionality
- Compute scores: `scdrs compute-score`. This perform the same function as python compute_score.py
- Downstream analyses: `scdrs perform-downstream`, which perform the same function as python compute_downstream.py
- Munge .gs file: `scdrs munge-gs`, which takes a gene set score file such as MAGMA association z-scores (or p-values) and format to the scdrs .gs format

The downstream analyses now only handle either one of the (1) group analysis (2) correlation analysis (3) gene analysis rather than performing all at once as in `python compute_downstream.py`. I think this way is cleaner.

The existing files are not changed to ensure the compatibility.

### Several utility functions are moved from cli script to `scdrs.util` module as these can be also reused in python API.
- `scdrs.util.convert_species_name`: taken from python compute_score.py
- `scdrs.util.load_h5ad`: Load h5ad file and optionally filter out cells and perform normalization
- `scdrs.util.load_drs_score`: Load drs scores, could be multiple score files, depend on the `score_path` parameter pattern. Either it is path to a single score file, such as /path/to/trait.full_score.gz  or a file pattern for multiple score files, such as /path/to/@.full_score.gz
- `scdrs.util.downstream_group_analysis`: Perform the group-level downstream analysis for scDRS results
- `scdrs.util.downstream_corr_analysis`: Perform the correlation between cell-level variables with scDRS scores
- `scdrs.util.downstream_gene_analysis`: Perform the correlation between gene-level variables with scDRS scores

### Discussion points
1. Whether to move the downstream code to scdrs.method
2. Better names on the functions.
3. Any other suggestions.