### PR TITLE
Update index.rst to fix a bug in the installation process

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,6 @@ Installation
 
    git clone https://github.com/martinjzhang/scDRS.git
    cd scDRS
-   git checkout -b v102 v1.0.2
    pip install -e .
    
 Quick test:


### PR DESCRIPTION
I found that this error was still not resolved after selecting the correct matplot lib version (https://github.com/martinjzhang/scDRS/issues/81). I investigate the codes installed in my envrionment and found that the default installation instruction is outdated and thus the installed codes are outdated (e.g., no returns from the function scdrs.util.plot_group_stats, and no validated inputs). I think it is ok to use the updated version for installation. 