### PR TITLE
Replace np.float_ with np.float64

### DIFF
--- a/scdrs/method.py
+++ b/scdrs/method.py
@@ -1052,14 +1052,14 @@ def gearys_c(adata, vals):
     """
     graph = adata.obsp["connectivities"]
     assert graph.shape[0] == graph.shape[1]
-    graph_data = graph.data.astype(np.float_, copy=False)
+    graph_data = graph.data.astype(np.float64, copy=False)
     assert graph.shape[0] == vals.shape[0]
     assert np.ndim(vals) == 1
 
     W = graph_data.sum()
     N = len(graph.indptr) - 1
     vals_bar = vals.mean()
-    vals = vals.astype(np.float_)
+    vals = vals.astype(np.float64)
 
     # numerators
     total = 0.0


### PR DESCRIPTION
This PR fixes the following error caused by the deprecation of `np.float_` in the NumPy 2.0 release

```
AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.. Did you mean: 'float16'?
```